### PR TITLE
joke generation eddpoint

### DIFF
--- a/src/main/java/uk/gegc/kidsgptbackend/controller/JokeController.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/controller/JokeController.java
@@ -1,0 +1,40 @@
+package uk.gegc.kidsgptbackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gegc.kidsgptbackend.dto.jokes.DailyJokeDto;
+import uk.gegc.kidsgptbackend.service.jokes.DailyJokeService;
+import uk.gegc.kidsgptbackend.model.user.AgeGroup;
+
+@RestController
+@RequestMapping("/api/v1/jokes")
+@RequiredArgsConstructor
+public class JokeController {
+
+    private final DailyJokeService dailyJokeService;
+
+    @GetMapping("/daily")
+    public ResponseEntity<DailyJokeDto> getDailyJoke(
+            @RequestParam(value = "ageGroup", required = false) String ageGroupParam
+    ) {
+        AgeGroup ageGroup = null;
+        if (ageGroupParam != null) {
+            try {
+                ageGroup = AgeGroup.valueOf(ageGroupParam.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                // Invalid age group parameter, will use default
+                ageGroup = null;
+            }
+        }
+        
+        DailyJokeDto joke = ageGroup != null ? 
+            dailyJokeService.getDailyJoke(ageGroup) : 
+            dailyJokeService.getDailyJoke();
+        
+        return ResponseEntity.ok(joke);
+    }
+} 

--- a/src/main/java/uk/gegc/kidsgptbackend/dto/jokes/DailyJokeDto.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/dto/jokes/DailyJokeDto.java
@@ -1,0 +1,11 @@
+package uk.gegc.kidsgptbackend.dto.jokes;
+
+import lombok.Data;
+
+@Data
+public class DailyJokeDto {
+    private String joke;
+    private String category; // e.g., "animals", "school", "science", "wordplay"
+    private String ageGroup; // e.g., "6-8", "9-10", "11-12"
+    private String imageUrl; // optional
+} 

--- a/src/main/java/uk/gegc/kidsgptbackend/service/jokes/DailyJokeService.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/service/jokes/DailyJokeService.java
@@ -1,0 +1,20 @@
+package uk.gegc.kidsgptbackend.service.jokes;
+
+import uk.gegc.kidsgptbackend.dto.jokes.DailyJokeDto;
+import uk.gegc.kidsgptbackend.model.user.AgeGroup;
+
+public interface DailyJokeService {
+    
+    /**
+     * Generates a fun, age-appropriate joke for the given age group
+     * @param ageGroup The age group enum
+     * @return A daily joke
+     */
+    DailyJokeDto getDailyJoke(AgeGroup ageGroup);
+    
+    /**
+     * Generates a fun, age-appropriate joke for the default age group (9-10)
+     * @return A daily joke
+     */
+    DailyJokeDto getDailyJoke();
+} 

--- a/src/main/java/uk/gegc/kidsgptbackend/service/jokes/impl/DailyJokeServiceImpl.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/service/jokes/impl/DailyJokeServiceImpl.java
@@ -1,0 +1,201 @@
+package uk.gegc.kidsgptbackend.service.jokes.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.messages.AbstractMessage;
+import org.springframework.ai.moderation.ModerationModel;
+import org.springframework.ai.moderation.ModerationPrompt;
+import org.springframework.ai.moderation.ModerationResponse;
+import org.springframework.ai.moderation.ModerationResult;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+import uk.gegc.kidsgptbackend.dto.jokes.DailyJokeDto;
+import uk.gegc.kidsgptbackend.exception.ModerationServiceException;
+import uk.gegc.kidsgptbackend.service.jokes.DailyJokeService;
+import org.springframework.util.StreamUtils;
+import uk.gegc.kidsgptbackend.model.user.AgeGroup;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DailyJokeServiceImpl implements DailyJokeService {
+
+    private final ChatClient chatClient;
+    private final ModerationModel moderationClient;
+    private final ResourceLoader resourceLoader;
+    private final Random random = new Random();
+
+    private static final List<String> CATEGORIES = Arrays.asList(
+            "animals", "school", "science", "wordplay", "food", "sports", "technology", "nature"
+    );
+
+    private static final List<String> JOKE_TYPES = Arrays.asList(
+            "animal jokes", "knock-knock jokes", "school jokes", "science puns",
+            "food jokes", "sports humor", "technology puns", "silly wordplay",
+            "nature jokes", "number jokes", "color jokes", "adventure humor"
+    );
+
+    @Override
+    public DailyJokeDto getDailyJoke() {
+        return getDailyJoke(AgeGroup.AGE_9_10); // Default age group
+    }
+
+    @Override
+    public DailyJokeDto getDailyJoke(AgeGroup ageGroup) {
+        log.info("=== Starting daily joke generation for age group: {} ===", ageGroup);
+
+        String prompt = getPromptForAgeGroup(ageGroup);
+        log.info("Loaded prompt for age group {}: {}", ageGroup, prompt);
+
+        try {
+            log.info("Making AI chat request...");
+            String randomJokeType = JOKE_TYPES.get(random.nextInt(JOKE_TYPES.size()));
+            log.info("Selected random joke type: {}", randomJokeType);
+
+            ChatResponse response = chatClient.prompt()
+                    .system(prompt)
+                    .user("Tell me a " + randomJokeType + "!")
+                    .call()
+                    .chatResponse();
+
+            log.info("AI response received - Response object: {}", response != null ? "NOT_NULL" : "NULL");
+
+            if (response != null) {
+                log.info("AI response result: {}", response.getResult());
+                if (response.getResult() != null) {
+                    log.info("AI response generation: {}", response.getResult().getOutput());
+                    if (response.getResult().getOutput() != null) {
+                        log.info("AI response text: '{}'", response.getResult().getOutput().getText());
+                    }
+                }
+            }
+
+            String joke = Optional.ofNullable(response)
+                    .map(ChatResponse::getResult)
+                    .map(Generation::getOutput)
+                    .map(AbstractMessage::getText)
+                    .orElse("Why don't elephants use computers? Because they're afraid of the mouse!");
+
+            log.info("Extracted joke from AI response: '{}'", joke);
+            log.info("Joke is fallback elephant joke: {}", joke.contains("elephants use computers"));
+
+            // Validate the generated joke is appropriate for the age group
+            log.info("Starting safety validation for age group: {}", ageGroup);
+            boolean isSafe = validateSafety(joke, ageGroup);
+            log.info("Safety validation result: {}", isSafe);
+
+            if (!isSafe) {
+                log.warn("Generated joke failed moderation for age group {}, using fallback", ageGroup);
+                joke = "Why don't elephants use computers? Because they're afraid of the mouse!";
+            }
+
+            DailyJokeDto dailyJoke = new DailyJokeDto();
+            dailyJoke.setJoke(joke);
+            dailyJoke.setCategory(CATEGORIES.get(random.nextInt(CATEGORIES.size())));
+            dailyJoke.setAgeGroup(ageGroup.name());
+            // imageUrl can be null for now, can be added later with image generation
+
+            log.info("=== Successfully generated daily joke: {} ===", dailyJoke);
+            return dailyJoke;
+
+        } catch (Exception e) {
+            log.error("=== Exception occurred during daily joke generation ===", e);
+            log.error("Exception type: {}", e.getClass().getSimpleName());
+            log.error("Exception message: {}", e.getMessage());
+
+            // Return a safe fallback joke
+            DailyJokeDto fallback = new DailyJokeDto();
+            fallback.setJoke("Why don't elephants use computers? Because they're afraid of the mouse!");
+            fallback.setCategory("animals");
+            fallback.setAgeGroup(ageGroup.name());
+            log.info("=== Returning fallback joke due to exception ===");
+            return fallback;
+        }
+    }
+
+    private String getPromptForAgeGroup(AgeGroup ageGroup) {
+        log.info("=== Loading prompt for age group: {} ===", ageGroup);
+
+        String resourcePath = switch (ageGroup) {
+            case AGE_6_8 -> "classpath:prompts/jokes/age-6-8.txt";
+            case AGE_9_10 -> "classpath:prompts/jokes/age-9-10.txt";
+            case AGE_11_12 -> "classpath:prompts/jokes/age-11-12.txt";
+            case AGE_13_14 -> "classpath:prompts/jokes/age-13-14.txt";
+            case AGE_15_16 -> "classpath:prompts/jokes/age-15-16.txt";
+        };
+
+        log.info("Resource path: {}", resourcePath);
+
+        try {
+            var resource = resourceLoader.getResource(resourcePath);
+            log.info("Resource loaded: {}", resource != null ? "SUCCESS" : "NULL");
+            log.info("Resource exists: {}", resource.exists());
+
+            String prompt = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+            log.info("Prompt loaded successfully, length: {} characters", prompt.length());
+            log.info("Prompt content: '{}'", prompt);
+            return prompt;
+        } catch (Exception e) {
+            log.error("=== Failed to load prompt for age group {} ===", ageGroup, e);
+            log.error("Exception type: {}", e.getClass().getSimpleName());
+            log.error("Exception message: {}", e.getMessage());
+            log.warn("Using fallback prompt for age group {}", ageGroup);
+            return "Generate a fun, safe, and age-appropriate joke for a child.";
+        }
+    }
+
+    private boolean validateSafety(String text, AgeGroup ageGroup) {
+        log.info("=== Starting safety validation ===");
+        log.info("Text to validate: '{}'", text);
+        log.info("Age group: {}", ageGroup);
+
+        try {
+            // Create age-specific moderation prompt
+            String moderationPrompt = String.format(
+                    "Check if this joke is appropriate for children aged %d-%d years old. " +
+                            "Consider age-appropriate language, humor, and content. " +
+                            "Joke: %s",
+                    ageGroup.getMinAge(), ageGroup.getMaxAge(), text
+            );
+
+            log.info("Moderation prompt: '{}'", moderationPrompt);
+            log.info("Calling moderation service...");
+
+            ModerationResponse response = moderationClient.call(new ModerationPrompt(moderationPrompt));
+            log.info("Moderation response received: {}", response != null ? "NOT_NULL" : "NULL");
+
+            if (response != null) {
+                log.info("Moderation result: {}", response.getResult());
+                if (response.getResult() != null) {
+                    log.info("Moderation output: {}", response.getResult().getOutput());
+                    if (response.getResult().getOutput() != null) {
+                        log.info("Moderation results count: {}", response.getResult().getOutput().getResults().size());
+                        response.getResult().getOutput().getResults().forEach(result -> {
+                            log.info("Moderation result - flagged: {}, categories: {}", result.isFlagged(), result.getCategories());
+                        });
+                    }
+                }
+            }
+
+            boolean isSafe = response.getResult().getOutput().getResults().stream()
+                    .noneMatch(ModerationResult::isFlagged);
+            log.info("Final safety validation result: {}", isSafe);
+            log.info("=== Safety validation completed ===");
+            return isSafe;
+        } catch (Exception ex) {
+            log.error("=== Moderation service call failed ===", ex);
+            log.error("Exception type: {}", ex.getClass().getSimpleName());
+            log.error("Exception message: {}", ex.getMessage());
+            throw new ModerationServiceException("Moderation service unavailable", ex);
+        }
+    }
+} 

--- a/src/main/resources/prompts/jokes/README.txt
+++ b/src/main/resources/prompts/jokes/README.txt
@@ -1,0 +1,37 @@
+# Prompts for Daily Jokes
+
+This directory contains prompt templates for generating daily age-appropriate jokes for different age groups.
+
+- age-6-8.txt: Prompt for children aged 6-8 (simple, silly jokes)
+- age-9-10.txt: Prompt for children aged 9-10 (clever wordplay and puns)
+- age-11-12.txt: Prompt for children aged 11-12 (witty and cool jokes)
+- age-13-14.txt: Prompt for teenagers aged 13-14 (relatable teenage humor)
+- age-15-16.txt: Prompt for teenagers aged 15-16 (sophisticated wordplay)
+
+## Structure
+
+Each file contains a prompt template that guides the AI to generate age-appropriate jokes with:
+- Appropriate complexity level for the age group
+- Safe and clean content
+- Engaging and entertaining humor
+- Educational or clever wordplay when suitable
+
+## Age Groups
+
+The age groups correspond to the `AgeGroup` enum in the codebase:
+- `AGE_6_8`: Ages 6-8 - Simple, silly jokes
+- `AGE_9_10`: Ages 9-10 - Clever puns and wordplay
+- `AGE_11_12`: Ages 11-12 - Witty and shareable jokes
+- `AGE_13_14`: Ages 13-14 - Relatable teenage humor
+- `AGE_15_16`: Ages 15-16 - Sophisticated and intelligent jokes
+
+## Joke Categories
+
+The jokes can fall into various categories:
+- Animals and nature
+- School and learning
+- Science and technology
+- Food and cooking
+- Sports and games
+- Wordplay and puns
+- Adventure and exploration 

--- a/src/main/resources/prompts/jokes/age-11-12.txt
+++ b/src/main/resources/prompts/jokes/age-11-12.txt
@@ -1,0 +1,25 @@
+You are a friendly joke-telling assistant for children aged 11-12.
+Generate a witty and entertaining joke that a pre-teen would find funny and cool.
+The joke should be:
+- Engaging for an 11-12 year old
+- Witty with clever wordplay
+- Cool and shareable with peers
+- Safe and appropriate for children
+- About 2-3 sentences long
+- NOT scary, mean, or inappropriate
+
+Choose from these cool joke types:
+- Smart animal and nature puns
+- Technology and gaming jokes
+- School life and teacher humor
+- Sports and competition jokes
+- Science and invention puns
+- Music and entertainment jokes
+- Adventure and mystery humor
+- Social media and internet puns (clean)
+
+Examples of appropriate jokes:
+- "Why did the math book look so sad? Because it had too many problems!"
+- "What do you call a bear with no teeth? A gummy bear!"
+
+Respond with ONLY the joke, nothing else. 

--- a/src/main/resources/prompts/jokes/age-13-14.txt
+++ b/src/main/resources/prompts/jokes/age-13-14.txt
@@ -1,0 +1,25 @@
+You are a friendly joke-telling assistant for teenagers aged 13-14.
+Generate a clever and entertaining joke that a young teenager would find funny and relatable.
+The joke should be:
+- Engaging for a 13-14 year old
+- Clever and somewhat sophisticated
+- Relatable to teenage experiences
+- Safe and appropriate for teenagers
+- About 2-3 sentences long
+- NOT mean-spirited, inappropriate, or offensive
+
+Choose from these relatable joke types:
+- School and academic life humor
+- Technology and social media jokes (clean)
+- Sports and activities puns
+- Music and pop culture references
+- Science and discovery humor
+- Friendship and social situations
+- Future and career jokes
+- Gaming and entertainment puns
+
+Examples of appropriate jokes:
+- "Why don't programmers like nature? It has too many bugs!"
+- "I told my computer I needed a break, and now it won't stop sending me Kit-Kat ads!"
+
+Respond with ONLY the joke, nothing else. 

--- a/src/main/resources/prompts/jokes/age-15-16.txt
+++ b/src/main/resources/prompts/jokes/age-15-16.txt
@@ -1,0 +1,25 @@
+You are a friendly joke-telling assistant for teenagers aged 15-16.
+Generate a smart and witty joke that an older teenager would find clever and entertaining.
+The joke should be:
+- Engaging for a 15-16 year old
+- Intelligent with sophisticated wordplay
+- Relatable to older teen experiences
+- Safe and appropriate for teenagers
+- About 2-3 sentences long
+- NOT offensive, inappropriate, or mean-spirited
+
+Choose from these sophisticated joke types:
+- Academic and intellectual humor
+- Technology and programming jokes
+- College prep and future planning humor
+- Advanced science and math puns
+- Literature and history references
+- Current events and world affairs (light)
+- Philosophy and deep thinking jokes
+- Career and adult life preparation humor
+
+Examples of appropriate jokes:
+- "I'm reading a book about anti-gravity. It's impossible to put down!"
+- "Parallel lines have so much in common. It's a shame they'll never meet!"
+
+Respond with ONLY the joke, nothing else. 

--- a/src/main/resources/prompts/jokes/age-6-8.txt
+++ b/src/main/resources/prompts/jokes/age-6-8.txt
@@ -1,0 +1,25 @@
+You are a friendly joke-telling assistant for children aged 6-8.
+Generate a simple, silly, and fun joke that a young child would find hilarious.
+The joke should be:
+- Easy to understand for a 6-8 year old
+- Silly and giggle-worthy
+- Safe and appropriate for children
+- Clean and wholesome
+- About 1-2 sentences long
+- NOT scary, mean, or inappropriate
+
+Choose from these fun joke types:
+- Animal jokes and puns
+- Knock-knock jokes
+- Simple wordplay
+- Silly question and answer jokes
+- Food puns
+- Number or counting jokes
+- Color and shape jokes
+- Simple riddles
+
+Examples of appropriate jokes:
+- "Why don't elephants use computers? Because they're afraid of the mouse!"
+- "What do you call a sleeping bull? A bulldozer!"
+
+Respond with ONLY the joke, nothing else. 

--- a/src/main/resources/prompts/jokes/age-9-10.txt
+++ b/src/main/resources/prompts/jokes/age-9-10.txt
@@ -1,0 +1,25 @@
+You are a friendly joke-telling assistant for children aged 9-10.
+Generate a fun and clever joke that a 9-10 year old would find amusing.
+The joke should be:
+- Engaging for a 9-10 year old
+- Clever with some wordplay
+- Fun and shareable with friends
+- Safe and appropriate for children
+- About 2-3 sentences long
+- NOT scary, mean, or inappropriate
+
+Choose from these entertaining joke types:
+- Clever animal puns
+- Knock-knock jokes with twists
+- School and homework jokes
+- Science and space puns
+- Sports and games jokes
+- Technology and gadget humor
+- Food and cooking puns
+- Adventure and exploration jokes
+
+Examples of appropriate jokes:
+- "Why don't scientists trust atoms? Because they make up everything!"
+- "What do you call a dinosaur that crashes his car? Tyrannosaurus Wrecks!"
+
+Respond with ONLY the joke, nothing else. 

--- a/src/test/java/uk/gegc/kidsgptbackend/controller/JokeControllerTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/controller/JokeControllerTest.java
@@ -1,0 +1,99 @@
+package uk.gegc.kidsgptbackend.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gegc.kidsgptbackend.dto.jokes.DailyJokeDto;
+import uk.gegc.kidsgptbackend.service.jokes.DailyJokeService;
+import uk.gegc.kidsgptbackend.model.user.AgeGroup;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = JokeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(JokeControllerTest.TestConfig.class)
+@DirtiesContext
+class JokeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DailyJokeService dailyJokeService;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        DailyJokeService dailyJokeService() {
+            return Mockito.mock(DailyJokeService.class);
+        }
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/jokes/daily: returns daily joke")
+    void getDailyJoke_returnsJoke() throws Exception {
+        // Given
+        DailyJokeDto joke = new DailyJokeDto();
+        joke.setJoke("Why don't elephants use computers? Because they're afraid of the mouse!");
+        joke.setCategory("animals");
+        joke.setAgeGroup("AGE_9_10");
+
+        when(dailyJokeService.getDailyJoke()).thenReturn(joke);
+
+        // When/Then
+        mockMvc.perform(get("/api/v1/jokes/daily"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.joke").value("Why don't elephants use computers? Because they're afraid of the mouse!"))
+                .andExpect(jsonPath("$.category").value("animals"))
+                .andExpect(jsonPath("$.ageGroup").value("AGE_9_10"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/jokes/daily with ageGroup: returns joke for specific age")
+    void getDailyJoke_withAgeGroup_returnsJokeForAge() throws Exception {
+        // Given
+        DailyJokeDto joke = new DailyJokeDto();
+        joke.setJoke("What do you call a sleeping bull? A bulldozer!");
+        joke.setCategory("animals");
+        joke.setAgeGroup("AGE_6_8");
+
+        when(dailyJokeService.getDailyJoke(AgeGroup.AGE_6_8)).thenReturn(joke);
+
+        // When/Then
+        mockMvc.perform(get("/api/v1/jokes/daily")
+                        .param("ageGroup", "AGE_6_8"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.joke").value("What do you call a sleeping bull? A bulldozer!"))
+                .andExpect(jsonPath("$.ageGroup").value("AGE_6_8"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/jokes/daily with invalid ageGroup: returns default joke")
+    void getDailyJoke_withInvalidAgeGroup_returnsDefaultJoke() throws Exception {
+        // Given
+        DailyJokeDto joke = new DailyJokeDto();
+        joke.setJoke("Why don't scientists trust atoms? Because they make up everything!");
+        joke.setCategory("science");
+        joke.setAgeGroup("AGE_9_10");
+
+        when(dailyJokeService.getDailyJoke()).thenReturn(joke);
+
+        // When/Then
+        mockMvc.perform(get("/api/v1/jokes/daily")
+                        .param("ageGroup", "INVALID_AGE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.joke").value("Why don't scientists trust atoms? Because they make up everything!"))
+                .andExpect(jsonPath("$.category").value("science"))
+                .andExpect(jsonPath("$.ageGroup").value("AGE_9_10"));
+    }
+} 


### PR DESCRIPTION
feat: Add daily jokes endpoint with age-appropriate content

- Add DailyJokeService with AI-powered joke generation
- Create /api/v1/jokes/daily endpoint with optional age group parameter
- Implement age-specific joke prompts for 5 different age groups (6-8, 9-10, 11-12, 13-14, 15-16)
- Add safety validation using moderation API
- Include fallback system for error handling
- Add comprehensive test suite with 3 test cases
- Follow same pattern as existing tips functionality

New files:
- src/main/resources/prompts/jokes/ (5 age-specific prompts + README)
- src/main/java/uk/gegc/kidsgptbackend/dto/jokes/DailyJokeDto.java
- src/main/java/uk/gegc/kidsgptbackend/service/jokes/DailyJokeService.java
- src/main/java/uk/gegc/kidsgptbackend/service/jokes/impl/DailyJokeServiceImpl.java
- src/main/java/uk/gegc/kidsgptbackend/controller/JokeController.java
- src/test/java/uk/gegc/kidsgptbackend/controller/JokeControllerTest.java