### PR TITLE
Add functionality for parents to retrieve their kids' profiles (#158)

### DIFF
--- a/src/main/java/uk/gegc/kidsgptbackend/controller/AuthController.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/controller/AuthController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import uk.gegc.kidsgptbackend.dto.auth.*;
@@ -13,6 +14,8 @@ import uk.gegc.kidsgptbackend.dto.user.KidRegistrationRequest;
 import uk.gegc.kidsgptbackend.dto.user.RegisterUserRequest;
 import uk.gegc.kidsgptbackend.dto.user.UserDto;
 import uk.gegc.kidsgptbackend.dto.user.UserProfileDto;
+
+import java.util.List;
 import uk.gegc.kidsgptbackend.service.auth.AuthService;
 import uk.gegc.kidsgptbackend.service.auth.PasswordResetService;
 
@@ -68,6 +71,16 @@ public class AuthController {
         }
         UserProfileDto profile = authService.getProfile(principal.getUsername());
         return ResponseEntity.ok(profile);
+    }
+
+    @GetMapping("/kids")
+    @PreAuthorize("hasRole('PARENT')")
+    public ResponseEntity<List<KidDto>> getMyKids(@AuthenticationPrincipal org.springframework.security.core.userdetails.User principal) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<KidDto> kids = authService.getParentKids(principal.getUsername());
+        return ResponseEntity.ok(kids);
     }
 
     @PostMapping("/forgot-password")

--- a/src/main/java/uk/gegc/kidsgptbackend/repository/family/KidRepository.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/repository/family/KidRepository.java
@@ -5,10 +5,12 @@ import org.springframework.stereotype.Repository;
 import uk.gegc.kidsgptbackend.model.family.Kid;
 
 import java.util.UUID;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface KidRepository extends JpaRepository<Kid, UUID> {
     Optional<Kid> findByParentId(UUID parentId);
+    List<Kid> findAllByParentId(UUID parentId);
     Optional<Kid> findByUserId(UUID userId);
 }

--- a/src/main/java/uk/gegc/kidsgptbackend/service/auth/AuthService.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/service/auth/AuthService.java
@@ -8,6 +8,8 @@ import uk.gegc.kidsgptbackend.dto.user.RegisterUserRequest;
 import uk.gegc.kidsgptbackend.dto.user.UserDto;
 import uk.gegc.kidsgptbackend.dto.user.UserProfileDto;
 
+import java.util.List;
+
 public interface AuthService {
     UserDto register(RegisterUserRequest request);
 
@@ -18,4 +20,6 @@ public interface AuthService {
     void logout(String token);
 
     UserProfileDto getProfile(String username);
+
+    List<KidDto> getParentKids(String parentUsername);
 }

--- a/src/main/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImpl.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImpl.java
@@ -36,7 +36,9 @@ import uk.gegc.kidsgptbackend.service.auth.AuthService;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +55,7 @@ public class AuthServiceImpl implements AuthService {
     private final RevokedTokenRepository revokedTokenRepository;
 
     @Override
+    @Transactional
     public UserDto register(RegisterUserRequest request) {
 
         if (userRepository.existsByUsername(request.username())) {
@@ -74,6 +77,16 @@ public class AuthServiceImpl implements AuthService {
         user.setRoles(new HashSet<>(Set.of(userRole)));
 
         User saved = userRepository.save(user);
+
+        // Create parent profile for parent users
+        if (userRole.getRole().equals(RoleName.ROLE_PARENT.name())) {
+            Parent parent = new Parent();
+            parent.setFirstName("Parent"); // Default first name
+            parent.setLastName("User");    // Default last name
+            parent.setEmail(request.email());
+            parentRepository.save(parent);
+        }
+
         return userMapper.toDto(saved);
     }
 
@@ -177,5 +190,32 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         return userMapper.toProfileDto(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<KidDto> getParentKids(String parentUsername) {
+        // Find parent user
+        User parentUser = userRepository.findByUsername(parentUsername)
+                .orElseThrow(() -> new ValidationException("Parent user not found"));
+
+        // Verify parent has ROLE_PARENT
+        boolean isParent = parentUser.getRoles().stream()
+                .anyMatch(role -> RoleName.ROLE_PARENT.name().equals(role.getRole()));
+        if (!isParent) {
+            throw new ValidationException("Only parents can retrieve their kids");
+        }
+
+        // Find parent profile
+        Parent parent = parentRepository.findByEmail(parentUser.getEmail())
+                .orElseThrow(() -> new ValidationException("Parent profile not found"));
+
+        // Find all kids belonging to this parent
+        List<Kid> kids = kidRepository.findAllByParentId(parent.getId());
+
+        // Convert to DTOs
+        return kids.stream()
+                .map(UserMapper::toKidDto)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gegc/kidsgptbackend/controller/AuthControllerKidRegistrationIntegrationTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/controller/AuthControllerKidRegistrationIntegrationTest.java
@@ -339,12 +339,8 @@ class AuthControllerKidRegistrationIntegrationTest {
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
 
-        // Create parent profile
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent");
-        parentProfile.setEmail(uniqueEmail);
-        parentRepository.save(parentProfile);
+        // Parent profile is now created automatically during registration
+        // No need to manually create it
 
         // Authenticate parent
         AuthLoginRequest parentLogin = new AuthLoginRequest(uniqueUsername, "parentpass123");

--- a/src/test/java/uk/gegc/kidsgptbackend/integration/BasicUserCreationIntegrationTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/integration/BasicUserCreationIntegrationTest.java
@@ -91,13 +91,6 @@ class BasicUserCreationIntegrationTest {
                 .andExpect(jsonPath("$.username").value("testparent"))
                 .andExpect(jsonPath("$.roles[0]").value("ROLE_PARENT"));
 
-        // Step 3: Create parent profile
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent");
-        parentProfile.setEmail("parent@example.com");
-        parentRepository.save(parentProfile);
-
         // Step 4: Authenticate parent
         AuthLoginRequest parentLogin = new AuthLoginRequest("testparent", "parentpass123");
         MvcResult parentAuthResult = mockMvc.perform(post("/api/v1/auth/login")
@@ -177,13 +170,6 @@ class BasicUserCreationIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
-
-        // Create parent profile
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent2");
-        parentProfile.setEmail("parent2@example.com");
-        parentRepository.save(parentProfile);
 
         // Authenticate parent
         AuthLoginRequest parentLogin = new AuthLoginRequest("testparent2", "parentpass123");

--- a/src/test/java/uk/gegc/kidsgptbackend/integration/ComprehensiveUserLifecycleIntegrationTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/integration/ComprehensiveUserLifecycleIntegrationTest.java
@@ -104,9 +104,6 @@ class ComprehensiveUserLifecycleIntegrationTest {
                 .andExpect(jsonPath("$.roles[0]").value("ROLE_PARENT"))
                 .andExpect(jsonPath("$.isActive").value(true));
 
-        // Create parent profile (required for kid creation)
-        createParentProfile(parentEmail);
-
         // Authenticate parent
         String parentToken = authenticateUser(parentUsername, "parentpass123");
         
@@ -220,48 +217,61 @@ class ComprehensiveUserLifecycleIntegrationTest {
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
 
-        createParentProfile(parentEmail);
+        // Authenticate parent
         String parentToken = authenticateUser(parentUsername, "parentpass123");
-
-        // Create two kids
-        KidRegistrationRequest kid1 = new KidRegistrationRequest("Emma", "emmapass", AgeGroup.AGE_9_10);
-        KidRegistrationRequest kid2 = new KidRegistrationRequest("Liam", "liampass", AgeGroup.AGE_13_14);
         
-        // Create first kid
-        MvcResult kid1Result = mockMvc.perform(post("/api/v1/auth/register-kid")
-                        .header("Authorization", "Bearer " + parentToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(kid1)))
-                .andExpect(status().isCreated())
-                .andReturn();
+        // Verify parent authentication state
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + parentToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(parentUsername))
+                .andExpect(jsonPath("$.role").value("ROLE_PARENT"));
 
-        JsonNode kid1Response = objectMapper.readTree(kid1Result.getResponse().getContentAsString());
-        String kid1Username = kid1Response.get("username").asText();
-        String kid1Id = kid1Response.get("id").asText();
+        // ===== CREATE MULTIPLE KIDS WITH DIFFERENT AGE GROUPS =====
+        String[] kidNames = {"Emma", "Liam"};
+        AgeGroup[] ageGroups = {AgeGroup.AGE_9_10, AgeGroup.AGE_13_14};
+        String[] kidUsernames = new String[2];
+        String[] kidIds = new String[2];
+        String[] kidTokens = new String[2];
 
-        // Create second kid
-        MvcResult kid2Result = mockMvc.perform(post("/api/v1/auth/register-kid")
-                        .header("Authorization", "Bearer " + parentToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(kid2)))
-                .andExpect(status().isCreated())
-                .andReturn();
+        for (int i = 0; i < 2; i++) {
+            // Parent creates kid
+            KidRegistrationRequest kidRequest = new KidRegistrationRequest(
+                    kidNames[i], 
+                    "kidpass" + i, 
+                    ageGroups[i]
+            );
+            
+            MvcResult kidResult = mockMvc.perform(post("/api/v1/auth/register-kid")
+                            .header("Authorization", "Bearer " + parentToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(kidRequest)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.nickname").value(kidNames[i]))
+                    .andExpect(jsonPath("$.ageGroup").value(ageGroups[i].name()))
+                    .andExpect(jsonPath("$.id").exists())
+                    .andReturn();
 
-        JsonNode kid2Response = objectMapper.readTree(kid2Result.getResponse().getContentAsString());
-        String kid2Username = kid2Response.get("username").asText();
-        String kid2Id = kid2Response.get("id").asText();
-        
-        // Verify both kids exist in database
-        assertThat(kidRepository.count()).isGreaterThanOrEqualTo(2);
-        
-        // Both kids can authenticate independently
-        String kid1Token = authenticateUser(kid1Username, "emmapass");
-        String kid2Token = authenticateUser(kid2Username, "liampass");
-        
-        // Each kid can update their own profile (only avatar)
+            JsonNode kidResponse = objectMapper.readTree(kidResult.getResponse().getContentAsString());
+            kidUsernames[i] = kidResponse.get("username").asText();
+            kidIds[i] = kidResponse.get("id").asText();
+            
+            // Kid authenticates
+            kidTokens[i] = authenticateUser(kidUsernames[i], "kidpass" + i);
+            
+            // Verify kid authentication state
+            mockMvc.perform(get("/api/v1/auth/me")
+                            .header("Authorization", "Bearer " + kidTokens[i]))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.username").value(kidUsernames[i]))
+                    .andExpect(jsonPath("$.role").value("ROLE_CHILD"));
+        }
+
+        // ===== PROFILE UPDATE SCENARIOS =====
+        // Kid updates their own profile (only avatar allowed)
         KidSelfUpdateRequest kid1Update = new KidSelfUpdateRequest("avatar1");
         mockMvc.perform(patch("/api/v1/profile")
-                        .header("Authorization", "Bearer " + kid1Token)
+                        .header("Authorization", "Bearer " + kidTokens[0])
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(kid1Update)))
                 .andExpect(status().isOk())
@@ -270,7 +280,7 @@ class ComprehensiveUserLifecycleIntegrationTest {
 
         KidSelfUpdateRequest kid2Update = new KidSelfUpdateRequest("avatar2");
         mockMvc.perform(patch("/api/v1/profile")
-                        .header("Authorization", "Bearer " + kid2Token)
+                        .header("Authorization", "Bearer " + kidTokens[1])
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(kid2Update)))
                 .andExpect(status().isOk())
@@ -279,7 +289,7 @@ class ComprehensiveUserLifecycleIntegrationTest {
 
         // Parent can update both kids via parent endpoint
         ParentUpdateKidRequest parentUpdateKid1 = new ParentUpdateKidRequest("Emma Updated", null, AgeGroup.AGE_11_12);
-        mockMvc.perform(patch("/api/v1/profile/kid/" + kid1Id)
+        mockMvc.perform(patch("/api/v1/profile/kid/" + kidIds[0])
                         .header("Authorization", "Bearer " + parentToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(parentUpdateKid1)))
@@ -302,7 +312,7 @@ class ComprehensiveUserLifecycleIntegrationTest {
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
 
-        createParentProfile(parentEmail);
+        // Authenticate parent
         String parentToken = authenticateUser(parentUsername, "parentpass123");
 
         // Create kid at AGE_6_8
@@ -358,14 +368,6 @@ class ComprehensiveUserLifecycleIntegrationTest {
         admin.setActive(true);
         admin.setRoles(new HashSet<>(Set.of(roleRepository.findByRole(RoleName.ROLE_ADMIN.name()).get())));
         return userRepository.save(admin);
-    }
-
-    private void createParentProfile(String email) {
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent");
-        parentProfile.setEmail(email);
-        parentRepository.save(parentProfile);
     }
 
     private String authenticateUser(String username, String password) throws Exception {

--- a/src/test/java/uk/gegc/kidsgptbackend/integration/ComprehensiveUserLifecycleTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/integration/ComprehensiveUserLifecycleTest.java
@@ -129,12 +129,6 @@ class ComprehensiveUserLifecycleTest {
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
 
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent");
-        parentProfile.setEmail(parentEmail);
-        parentRepository.save(parentProfile);
-
         AuthLoginRequest parentLogin = new AuthLoginRequest(parentUsername, "parentpass123");
         MvcResult parentResult = mockMvc.perform(post("/api/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -189,12 +183,6 @@ class ComprehensiveUserLifecycleTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
-
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent");
-        parentProfile.setEmail(parentEmail);
-        parentRepository.save(parentProfile);
 
         AuthLoginRequest parentLogin = new AuthLoginRequest(parentUsername, "parentpass123");
         MvcResult parentResult = mockMvc.perform(post("/api/v1/auth/login")

--- a/src/test/java/uk/gegc/kidsgptbackend/integration/UserLifecycleIntegrationTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/integration/UserLifecycleIntegrationTest.java
@@ -81,13 +81,6 @@ class UserLifecycleIntegrationTest {
                         .content(objectMapper.writeValueAsString(parentRequest)))
                 .andExpect(status().isCreated());
 
-        // Create parent profile
-        Parent parentProfile = new Parent();
-        parentProfile.setFirstName("Test");
-        parentProfile.setLastName("Parent");
-        parentProfile.setEmail(parentEmail);
-        parentRepository.save(parentProfile);
-
         // Authenticate parent
         AuthLoginRequest parentLogin = new AuthLoginRequest(parentUsername, "parentpass123");
         MvcResult parentAuthResult = mockMvc.perform(post("/api/v1/auth/login")

--- a/src/test/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImplTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImplTest.java
@@ -37,6 +37,9 @@ import uk.gegc.kidsgptbackend.repository.user.RoleRepository;
 import uk.gegc.kidsgptbackend.repository.user.UserRepository;
 import uk.gegc.kidsgptbackend.security.JwtTokenProvider;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -334,5 +337,176 @@ public class AuthServiceImplTest {
         assertThatThrownBy(() -> authService.login(req))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining(String.valueOf(HttpStatus.UNAUTHORIZED.value()));
+    }
+
+    // Get Parent Kids Tests
+    @Test
+    @DisplayName("getParentKids: successful retrieval with multiple kids")
+    void getParentKids_success_multipleKids() {
+        // Given
+        String parentUsername = "parent123";
+        UUID parentId = UUID.randomUUID();
+        
+        User parentUser = new User();
+        parentUser.setId(UUID.randomUUID());
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        Parent parent = new Parent();
+        parent.setId(parentId);
+        parent.setEmail("parent@example.com");
+        
+        User kidUser1 = new User();
+        kidUser1.setId(UUID.randomUUID());
+        kidUser1.setUsername("emma_kid");
+        
+        User kidUser2 = new User();
+        kidUser2.setId(UUID.randomUUID());
+        kidUser2.setUsername("liam_kid");
+        
+        Kid kid1 = new Kid();
+        kid1.setId(UUID.randomUUID());
+        kid1.setNickname("Emma");
+        kid1.setAgeGroup(AgeGroup.AGE_6_8);
+        kid1.setUser(kidUser1);
+        kid1.setParent(parent);
+        
+        Kid kid2 = new Kid();
+        kid2.setId(UUID.randomUUID());
+        kid2.setNickname("Liam");
+        kid2.setAgeGroup(AgeGroup.AGE_9_10);
+        kid2.setUser(kidUser2);
+        kid2.setParent(parent);
+        
+        List<Kid> kids = Arrays.asList(kid1, kid2);
+        
+        // When
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.of(parent));
+        when(kidRepository.findAllByParentId(parentId)).thenReturn(kids);
+        
+        List<KidDto> result = authService.getParentKids(parentUsername);
+        
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).nickname()).isEqualTo("Emma");
+        assertThat(result.get(0).username()).isEqualTo("emma_kid");
+        assertThat(result.get(0).ageGroup()).isEqualTo(AgeGroup.AGE_6_8);
+        assertThat(result.get(1).nickname()).isEqualTo("Liam");
+        assertThat(result.get(1).username()).isEqualTo("liam_kid");
+        assertThat(result.get(1).ageGroup()).isEqualTo(AgeGroup.AGE_9_10);
+        
+        verify(userRepository).findByUsername(parentUsername);
+        verify(parentRepository).findByEmail("parent@example.com");
+        verify(kidRepository).findAllByParentId(parentId);
+    }
+
+    @Test
+    @DisplayName("getParentKids: successful retrieval with no kids")
+    void getParentKids_success_noKids() {
+        // Given
+        String parentUsername = "parent123";
+        UUID parentId = UUID.randomUUID();
+        
+        User parentUser = new User();
+        parentUser.setId(UUID.randomUUID());
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        Parent parent = new Parent();
+        parent.setId(parentId);
+        parent.setEmail("parent@example.com");
+        
+        // When
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.of(parent));
+        when(kidRepository.findAllByParentId(parentId)).thenReturn(Collections.emptyList());
+        
+        List<KidDto> result = authService.getParentKids(parentUsername);
+        
+        // Then
+        assertThat(result).isEmpty();
+        
+        verify(userRepository).findByUsername(parentUsername);
+        verify(parentRepository).findByEmail("parent@example.com");
+        verify(kidRepository).findAllByParentId(parentId);
+    }
+
+    @Test
+    @DisplayName("getParentKids: throws ValidationException when parent user not found")
+    void getParentKids_parentUserNotFound_throws() {
+        // Given
+        String parentUsername = "nonexistent";
+        
+        // When
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.empty());
+        
+        // Then
+        assertThatThrownBy(() -> authService.getParentKids(parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Parent user not found");
+        
+        verify(userRepository).findByUsername(parentUsername);
+        verifyNoInteractions(parentRepository, kidRepository);
+    }
+
+    @Test
+    @DisplayName("getParentKids: throws ValidationException when user is not a parent")
+    void getParentKids_userNotParent_throws() {
+        // Given
+        String username = "childuser";
+        
+        User childUser = new User();
+        childUser.setId(UUID.randomUUID());
+        childUser.setUsername(username);
+        childUser.setEmail("child@example.com");
+        Role childRole = new Role();
+        childRole.setRole(RoleName.ROLE_CHILD.name());
+        childUser.setRoles(Set.of(childRole));
+        
+        // When
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(childUser));
+        
+        // Then
+        assertThatThrownBy(() -> authService.getParentKids(username))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Only parents can retrieve their kids");
+        
+        verify(userRepository).findByUsername(username);
+        verifyNoInteractions(parentRepository, kidRepository);
+    }
+
+    @Test
+    @DisplayName("getParentKids: throws ValidationException when parent profile not found")
+    void getParentKids_parentProfileNotFound_throws() {
+        // Given
+        String parentUsername = "parent123";
+        
+        User parentUser = new User();
+        parentUser.setId(UUID.randomUUID());
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        // When
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.empty());
+        
+        // Then
+        assertThatThrownBy(() -> authService.getParentKids(parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Parent profile not found");
+        
+        verify(userRepository).findByUsername(parentUsername);
+        verify(parentRepository).findByEmail("parent@example.com");
+        verifyNoInteractions(kidRepository);
     }
 }


### PR DESCRIPTION
- Introduced a new endpoint in AuthController to allow parents to fetch a list of their children using the /kids route, secured with @PreAuthorize for role validation.
- Enhanced AuthService with a method to retrieve kids associated with a parent, including role checks and profile validation.
- Updated KidRepository to support fetching all kids by parent ID.
- Refactored integration tests to validate the new functionality, ensuring proper role-based access and response handling for parent requests.