### PR TITLE
Add delete functionality for kids and parent accounts in AuthControll…

### DIFF
--- a/src/main/java/uk/gegc/kidsgptbackend/controller/AuthController.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/controller/AuthController.java
@@ -11,11 +11,13 @@ import org.springframework.web.bind.annotation.*;
 import uk.gegc.kidsgptbackend.dto.auth.*;
 import uk.gegc.kidsgptbackend.dto.user.KidDto;
 import uk.gegc.kidsgptbackend.dto.user.KidRegistrationRequest;
+import uk.gegc.kidsgptbackend.dto.user.ParentDto;
 import uk.gegc.kidsgptbackend.dto.user.RegisterUserRequest;
 import uk.gegc.kidsgptbackend.dto.user.UserDto;
 import uk.gegc.kidsgptbackend.dto.user.UserProfileDto;
 
 import java.util.List;
+import java.util.UUID;
 import uk.gegc.kidsgptbackend.service.auth.AuthService;
 import uk.gegc.kidsgptbackend.service.auth.PasswordResetService;
 
@@ -34,6 +36,8 @@ public class AuthController {
         UserDto createdUser = authService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
+
+
 
     @PostMapping("/register-kid")
     public ResponseEntity<KidDto> registerKid(
@@ -103,5 +107,30 @@ public class AuthController {
     public ResponseEntity<Boolean> validateResetToken(@RequestParam String token) {
         boolean isValid = passwordResetService.validateResetToken(token);
         return ResponseEntity.ok(isValid);
+    }
+
+    @DeleteMapping("/kids/{kidId}")
+    @PreAuthorize("hasRole('PARENT')")
+    public ResponseEntity<Void> deleteKid(
+            @PathVariable UUID kidId,
+            @AuthenticationPrincipal org.springframework.security.core.userdetails.User principal
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        authService.deleteKid(kidId, principal.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/account")
+    @PreAuthorize("hasRole('PARENT')")
+    public ResponseEntity<Void> deleteParentAccount(
+            @AuthenticationPrincipal org.springframework.security.core.userdetails.User principal
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        authService.deleteParentAccount(principal.getUsername());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gegc/kidsgptbackend/dto/user/ParentDto.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/dto/user/ParentDto.java
@@ -1,0 +1,11 @@
+package uk.gegc.kidsgptbackend.dto.user;
+
+import java.util.UUID;
+
+public record ParentDto(
+    UUID id,
+    String firstName,
+    String lastName,
+    String email,
+    String phoneNumber
+) {} 

--- a/src/main/java/uk/gegc/kidsgptbackend/service/auth/AuthService.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/service/auth/AuthService.java
@@ -4,11 +4,13 @@ import uk.gegc.kidsgptbackend.dto.auth.AuthLoginRequest;
 import uk.gegc.kidsgptbackend.dto.auth.AuthTokensResponse;
 import uk.gegc.kidsgptbackend.dto.user.KidDto;
 import uk.gegc.kidsgptbackend.dto.user.KidRegistrationRequest;
+import uk.gegc.kidsgptbackend.dto.user.ParentDto;
 import uk.gegc.kidsgptbackend.dto.user.RegisterUserRequest;
 import uk.gegc.kidsgptbackend.dto.user.UserDto;
 import uk.gegc.kidsgptbackend.dto.user.UserProfileDto;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface AuthService {
     UserDto register(RegisterUserRequest request);
@@ -22,4 +24,8 @@ public interface AuthService {
     UserProfileDto getProfile(String username);
 
     List<KidDto> getParentKids(String parentUsername);
+    
+    void deleteKid(UUID kidId, String parentUsername);
+    
+    void deleteParentAccount(String parentUsername);
 }

--- a/src/main/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImpl.java
+++ b/src/main/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImpl.java
@@ -14,6 +14,7 @@ import uk.gegc.kidsgptbackend.dto.auth.AuthLoginRequest;
 import uk.gegc.kidsgptbackend.dto.auth.AuthTokensResponse;
 import uk.gegc.kidsgptbackend.dto.user.KidDto;
 import uk.gegc.kidsgptbackend.dto.user.KidRegistrationRequest;
+import uk.gegc.kidsgptbackend.dto.user.ParentDto;
 import uk.gegc.kidsgptbackend.dto.user.RegisterUserRequest;
 import uk.gegc.kidsgptbackend.dto.user.UserDto;
 import uk.gegc.kidsgptbackend.dto.user.UserProfileDto;
@@ -38,6 +39,7 @@ import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -89,6 +91,8 @@ public class AuthServiceImpl implements AuthService {
 
         return userMapper.toDto(saved);
     }
+
+
 
     @Override
     @Transactional
@@ -217,5 +221,73 @@ public class AuthServiceImpl implements AuthService {
         return kids.stream()
                 .map(UserMapper::toKidDto)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteKid(UUID kidId, String parentUsername) {
+        // Find parent user
+        User parentUser = userRepository.findByUsername(parentUsername)
+                .orElseThrow(() -> new ValidationException("Parent user not found"));
+
+        // Verify parent has ROLE_PARENT
+        boolean isParent = parentUser.getRoles().stream()
+                .anyMatch(role -> RoleName.ROLE_PARENT.name().equals(role.getRole()));
+        if (!isParent) {
+            throw new ValidationException("Only parents can delete kid accounts");
+        }
+
+        // Find parent profile
+        Parent parent = parentRepository.findByEmail(parentUser.getEmail())
+                .orElseThrow(() -> new ValidationException("Parent profile not found"));
+
+        // Find the kid by ID and verify it belongs to this parent
+        Kid kid = kidRepository.findById(kidId)
+                .orElseThrow(() -> new ValidationException("Kid not found"));
+
+        if (!kid.getParent().getId().equals(parent.getId())) {
+            throw new ValidationException("You can only delete your own kids' accounts");
+        }
+
+        // Check if kid has a user account
+        if (kid.getUser() == null) {
+            throw new ValidationException("Kid user account not found");
+        }
+
+        // Delete the kid's user account
+        userRepository.delete(kid.getUser());
+
+        // Delete the kid profile
+        kidRepository.delete(kid);
+    }
+
+    @Override
+    @Transactional
+    public void deleteParentAccount(String parentUsername) {
+        // Find parent user
+        User parentUser = userRepository.findByUsername(parentUsername)
+                .orElseThrow(() -> new ValidationException("Parent user not found"));
+
+        // Verify parent has ROLE_PARENT
+        boolean isParent = parentUser.getRoles().stream()
+                .anyMatch(role -> RoleName.ROLE_PARENT.name().equals(role.getRole()));
+        if (!isParent) {
+            throw new ValidationException("Only parents can delete their accounts");
+        }
+
+        // Find parent profile
+        Parent parent = parentRepository.findByEmail(parentUser.getEmail())
+                .orElseThrow(() -> new ValidationException("Parent profile not found"));
+
+        // Check if parent has kids
+        if (!parent.getKids().isEmpty()) {
+            throw new ValidationException("Cannot delete parent account with existing kids. Please delete all kids first.");
+        }
+
+        // Delete the parent's user account
+        userRepository.delete(parentUser);
+
+        // Delete the parent profile
+        parentRepository.delete(parent);
     }
 }

--- a/src/test/java/uk/gegc/kidsgptbackend/controller/AuthControllerKidRegistrationIntegrationTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/controller/AuthControllerKidRegistrationIntegrationTest.java
@@ -27,6 +27,7 @@ import uk.gegc.kidsgptbackend.repository.user.RoleRepository;
 import uk.gegc.kidsgptbackend.repository.user.UserRepository;
 
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -321,6 +322,150 @@ class AuthControllerKidRegistrationIntegrationTest {
                             .content(objectMapper.writeValueAsString(kidLogin)))
                     .andExpect(status().isOk());
         }
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/auth/kids/{kidId} → 204 for valid parent request")
+    void deleteKid_validParentRequest_returnsNoContent() throws Exception {
+        // First create a kid
+        KidRegistrationRequest createRequest = new KidRegistrationRequest(
+                "KidToDelete",
+                "password123",
+                AgeGroup.AGE_9_10
+        );
+
+        MvcResult createResult = mockMvc.perform(post("/api/v1/auth/register-kid")
+                        .header("Authorization", "Bearer " + parentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createResponse = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String kidId = createResponse.get("id").asText();
+        String kidUsername = createResponse.get("username").asText();
+
+        // Verify kid exists and can login
+        AuthLoginRequest kidLogin = new AuthLoginRequest(kidUsername, "password123");
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(kidLogin)))
+                .andExpect(status().isOk());
+
+        // Delete the kid
+        mockMvc.perform(delete("/api/v1/auth/kids/" + kidId)
+                        .header("Authorization", "Bearer " + parentToken))
+                .andExpect(status().isNoContent());
+
+        // Verify kid no longer exists
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(kidLogin)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/auth/kids/{kidId} → 400 when kid not found")
+    void deleteKid_kidNotFound_returnsBadRequest() throws Exception {
+        UUID nonExistentKidId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/auth/kids/" + nonExistentKidId)
+                        .header("Authorization", "Bearer " + parentToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.details").value("Kid not found"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/auth/kids/{kidId} → 401 when not authenticated")
+    void deleteKid_notAuthenticated_returnsUnauthorized() throws Exception {
+        UUID kidId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/auth/kids/" + kidId))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/auth/kids/{kidId} → 403 when user is not a parent")
+    void deleteKid_userNotParent_returnsForbidden() throws Exception {
+        // Given - Create and authenticate a child user
+        String uniqueId = String.valueOf(System.currentTimeMillis()).substring(7);
+        User childUser = new User();
+        childUser.setUsername("c" + uniqueId);
+        childUser.setEmail("child" + uniqueId + "@test.com");
+        childUser.setHashedPassword(passwordEncoder.encode("password123"));
+        childUser.setActive(true);
+        childUser.setRoles(Set.of(roleRepository.findByRole(RoleName.ROLE_CHILD.name()).get()));
+        userRepository.save(childUser);
+
+        // Authenticate as child
+        AuthLoginRequest childLogin = new AuthLoginRequest(childUser.getUsername(), "password123");
+        MvcResult childAuthResult = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(childLogin)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode childResponse = objectMapper.readTree(childAuthResult.getResponse().getContentAsString());
+        String childToken = childResponse.get("accessToken").asText();
+
+        UUID kidId = UUID.randomUUID();
+
+        // When & Then - Spring Security blocks access before reaching service
+        mockMvc.perform(delete("/api/v1/auth/kids/" + kidId)
+                        .header("Authorization", "Bearer " + childToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value("Access Denied"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/auth/kids/{kidId} → 400 when trying to delete another parent's kid")
+    void deleteKid_anotherParentKid_returnsBadRequest() throws Exception {
+        // Create a second parent
+        String uniqueId = String.valueOf(System.currentTimeMillis()).substring(7);
+        String secondParentUsername = "p2" + uniqueId;
+        String secondParentEmail = "parent2" + uniqueId + "@test.com";
+        
+        RegisterUserRequest secondParentRequest = new RegisterUserRequest(secondParentUsername, secondParentEmail, "parentpass123");
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(secondParentRequest)))
+                .andExpect(status().isCreated());
+
+        // Authenticate second parent
+        AuthLoginRequest secondParentLogin = new AuthLoginRequest(secondParentUsername, "parentpass123");
+        MvcResult secondParentAuthResult = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(secondParentLogin)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode secondParentResponse = objectMapper.readTree(secondParentAuthResult.getResponse().getContentAsString());
+        String secondParentToken = secondParentResponse.get("accessToken").asText();
+
+        // Create a kid with the first parent
+        KidRegistrationRequest createRequest = new KidRegistrationRequest(
+                "KidToDelete",
+                "password123",
+                AgeGroup.AGE_9_10
+        );
+
+        MvcResult createResult = mockMvc.perform(post("/api/v1/auth/register-kid")
+                        .header("Authorization", "Bearer " + parentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        JsonNode createResponse = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        String kidId = createResponse.get("id").asText();
+
+        // Try to delete with second parent (should fail)
+        mockMvc.perform(delete("/api/v1/auth/kids/" + kidId)
+                        .header("Authorization", "Bearer " + secondParentToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.details").value("You can only delete your own kids' accounts"));
     }
 
     private void setupParentUser() throws Exception {

--- a/src/test/java/uk/gegc/kidsgptbackend/integration/DatabaseSchemaIntegrationTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/integration/DatabaseSchemaIntegrationTest.java
@@ -1,0 +1,160 @@
+package uk.gegc.kidsgptbackend.integration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gegc.kidsgptbackend.model.family.Kid;
+import uk.gegc.kidsgptbackend.model.family.Parent;
+import uk.gegc.kidsgptbackend.model.user.AgeGroup;
+import uk.gegc.kidsgptbackend.model.user.Role;
+import uk.gegc.kidsgptbackend.model.user.RoleName;
+import uk.gegc.kidsgptbackend.model.user.User;
+import uk.gegc.kidsgptbackend.repository.family.KidRepository;
+import uk.gegc.kidsgptbackend.repository.family.ParentRepository;
+import uk.gegc.kidsgptbackend.repository.user.RoleRepository;
+import uk.gegc.kidsgptbackend.repository.user.UserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Database Schema Integration Tests")
+class DatabaseSchemaIntegrationTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private KidRepository kidRepository;
+
+    @Autowired
+    private ParentRepository parentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Test
+    @DisplayName("Kids table should not have first_name and last_name fields")
+    void kidsTableShouldNotHaveNameFields() {
+        // Get the metamodel for the Kid entity
+        Metamodel metamodel = entityManager.getMetamodel();
+        EntityType<Kid> kidEntityType = metamodel.entity(Kid.class);
+        
+        // Verify that the Kid entity doesn't have first_name or last_name fields
+        Set<String> attributeNames = kidEntityType.getDeclaredSingularAttributes().stream()
+                .map(attr -> attr.getName())
+                .collect(java.util.stream.Collectors.toSet());
+        
+        assertThat(attributeNames).doesNotContain("firstName");
+        assertThat(attributeNames).doesNotContain("lastName");
+        assertThat(attributeNames).doesNotContain("first_name");
+        assertThat(attributeNames).doesNotContain("last_name");
+        
+        // Verify that the Kid entity has the correct fields for anonymous kids
+        assertThat(attributeNames).contains("nickname");
+        assertThat(attributeNames).contains("ageGroup");
+        assertThat(attributeNames).contains("parent");
+        assertThat(attributeNames).contains("user");
+    }
+
+    @Test
+    @DisplayName("Kid entity should be able to persist without first_name and last_name")
+    void kidEntityShouldPersistWithoutNameFields() {
+        // Ensure roles exist
+        Role childRole = roleRepository.findByRole(RoleName.ROLE_CHILD.name())
+                .orElseGet(() -> {
+                    Role role = new Role();
+                    role.setRole(RoleName.ROLE_CHILD.name());
+                    return roleRepository.save(role);
+                });
+
+        Role parentRole = roleRepository.findByRole(RoleName.ROLE_PARENT.name())
+                .orElseGet(() -> {
+                    Role role = new Role();
+                    role.setRole(RoleName.ROLE_PARENT.name());
+                    return roleRepository.save(role);
+                });
+
+        // Create parent user
+        User parentUser = new User();
+        parentUser.setUsername("testparent" + System.currentTimeMillis());
+        parentUser.setEmail("parent@test.com");
+        parentUser.setHashedPassword("hashedPassword");
+        parentUser.setRoles(Set.of(parentRole));
+        parentUser.setActive(true);
+        parentUser = userRepository.save(parentUser);
+
+        // Create parent profile
+        Parent parent = new Parent();
+        parent.setFirstName("Test");
+        parent.setLastName("Parent");
+        parent.setEmail("parent@test.com");
+        parent = parentRepository.save(parent);
+
+        // Create kid user
+        User kidUser = new User();
+        kidUser.setUsername("testkid" + System.currentTimeMillis());
+        kidUser.setEmail("testkid@kid.local");
+        kidUser.setHashedPassword("hashedPassword");
+        kidUser.setRoles(Set.of(childRole));
+        kidUser.setActive(true);
+        kidUser = userRepository.save(kidUser);
+
+        // Create kid - this should work without first_name and last_name
+        Kid kid = new Kid();
+        kid.setNickname("TestKid");
+        kid.setAgeGroup(AgeGroup.AGE_6_8);
+        kid.setParent(parent);
+        kid.setUser(kidUser);
+
+        // This should not throw an exception about missing first_name/last_name
+        Kid savedKid = kidRepository.save(kid);
+        
+        assertThat(savedKid).isNotNull();
+        assertThat(savedKid.getId()).isNotNull();
+        assertThat(savedKid.getNickname()).isEqualTo("TestKid");
+        assertThat(savedKid.getAgeGroup()).isEqualTo(AgeGroup.AGE_6_8);
+        assertThat(savedKid.getParent()).isEqualTo(parent);
+        assertThat(savedKid.getUser()).isEqualTo(kidUser);
+    }
+
+    @Test
+    @DisplayName("Kid entity should only have fields appropriate for anonymous children")
+    void kidEntityShouldHaveAppropriateFieldsForAnonymousChildren() {
+        // Get the metamodel for the Kid entity
+        Metamodel metamodel = entityManager.getMetamodel();
+        EntityType<Kid> kidEntityType = metamodel.entity(Kid.class);
+        
+        Set<String> attributeNames = kidEntityType.getDeclaredSingularAttributes().stream()
+                .map(attr -> attr.getName())
+                .collect(java.util.stream.Collectors.toSet());
+        
+        // Verify that Kid entity has only appropriate fields for anonymous children
+        assertThat(attributeNames).containsExactlyInAnyOrder(
+                "id", "nickname", "age", "favoriteColor", "avatarId", 
+                "interests", "parent", "user", "ageGroup"
+        );
+        
+        // Verify that there are no personal identification fields
+        assertThat(attributeNames).doesNotContain("firstName");
+        assertThat(attributeNames).doesNotContain("lastName");
+        assertThat(attributeNames).doesNotContain("first_name");
+        assertThat(attributeNames).doesNotContain("last_name");
+        assertThat(attributeNames).doesNotContain("fullName");
+        assertThat(attributeNames).doesNotContain("realName");
+        assertThat(attributeNames).doesNotContain("legalName");
+    }
+} 

--- a/src/test/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImplTest.java
+++ b/src/test/java/uk/gegc/kidsgptbackend/service/auth/impl/AuthServiceImplTest.java
@@ -509,4 +509,178 @@ public class AuthServiceImplTest {
         verify(parentRepository).findByEmail("parent@example.com");
         verifyNoInteractions(kidRepository);
     }
+
+    @Test
+    @DisplayName("deleteKid: successful deletion by parent")
+    void deleteKid_success() {
+        // Given
+        UUID kidId = UUID.randomUUID();
+        String parentUsername = "parent123";
+        UUID parentId = UUID.randomUUID();
+        UUID kidUserId = UUID.randomUUID();
+        
+        User parentUser = new User();
+        parentUser.setId(UUID.randomUUID());
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        Parent parent = new Parent();
+        parent.setId(parentId);
+        parent.setEmail("parent@example.com");
+        
+        User kidUser = new User();
+        kidUser.setId(kidUserId);
+        kidUser.setUsername("emma_kid");
+        
+        Kid kid = new Kid();
+        kid.setId(kidId);
+        kid.setNickname("Emma");
+        kid.setUser(kidUser);
+        kid.setParent(parent);
+        
+        // When
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.of(parent));
+        when(kidRepository.findById(kidId)).thenReturn(Optional.of(kid));
+        
+        authService.deleteKid(kidId, parentUsername);
+        
+        // Then
+        verify(kidRepository).delete(kid);
+        verify(userRepository).delete(kidUser);
+    }
+
+    @Test
+    @DisplayName("deleteKid: throws ValidationException when parent user not found")
+    void deleteKid_parentUserNotFound_throws() {
+        UUID kidId = UUID.randomUUID();
+        String parentUsername = "nonexistent";
+        
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.deleteKid(kidId, parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Parent user not found");
+    }
+
+    @Test
+    @DisplayName("deleteKid: throws ValidationException when user is not a parent")
+    void deleteKid_userNotParent_throws() {
+        UUID kidId = UUID.randomUUID();
+        String parentUsername = "user";
+        
+        User nonParentUser = new User();
+        nonParentUser.setUsername("user");
+        Role childRole = new Role();
+        childRole.setRole(RoleName.ROLE_CHILD.name());
+        nonParentUser.setRoles(Set.of(childRole));
+        
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(nonParentUser));
+
+        assertThatThrownBy(() -> authService.deleteKid(kidId, parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Only parents can delete kid accounts");
+    }
+
+    @Test
+    @DisplayName("deleteKid: throws ValidationException when kid not found")
+    void deleteKid_kidNotFound_throws() {
+        UUID kidId = UUID.randomUUID();
+        String parentUsername = "parent123";
+        
+        User parentUser = new User();
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        Parent parent = new Parent();
+        parent.setEmail("parent@example.com");
+        
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.of(parent));
+        when(kidRepository.findById(kidId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.deleteKid(kidId, parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Kid not found");
+    }
+
+    @Test
+    @DisplayName("deleteKid: throws ValidationException when trying to delete another parent's kid")
+    void deleteKid_anotherParentKid_throws() {
+        UUID kidId = UUID.randomUUID();
+        String parentUsername = "parent123";
+        UUID parentId = UUID.randomUUID();
+        UUID otherParentId = UUID.randomUUID();
+        
+        User parentUser = new User();
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        Parent parent = new Parent();
+        parent.setId(parentId);
+        parent.setEmail("parent@example.com");
+        
+        Parent otherParent = new Parent();
+        otherParent.setId(otherParentId);
+        otherParent.setEmail("other@example.com");
+        
+        User kidUser = new User();
+        kidUser.setUsername("emma_kid");
+        
+        Kid kid = new Kid();
+        kid.setId(kidId);
+        kid.setNickname("Emma");
+        kid.setUser(kidUser);
+        kid.setParent(otherParent); // Kid belongs to different parent
+        
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.of(parent));
+        when(kidRepository.findById(kidId)).thenReturn(Optional.of(kid));
+
+        assertThatThrownBy(() -> authService.deleteKid(kidId, parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("You can only delete your own kids' accounts");
+    }
+
+    @Test
+    @DisplayName("deleteKid: throws ValidationException when kid user account not found")
+    void deleteKid_kidUserNotFound_throws() {
+        UUID kidId = UUID.randomUUID();
+        String parentUsername = "parent123";
+        UUID parentId = UUID.randomUUID();
+        
+        User parentUser = new User();
+        parentUser.setUsername(parentUsername);
+        parentUser.setEmail("parent@example.com");
+        Role parentRole = new Role();
+        parentRole.setRole(RoleName.ROLE_PARENT.name());
+        parentUser.setRoles(Set.of(parentRole));
+        
+        Parent parent = new Parent();
+        parent.setId(parentId);
+        parent.setEmail("parent@example.com");
+        
+        Kid kid = new Kid();
+        kid.setId(kidId);
+        kid.setNickname("Emma");
+        kid.setUser(null); // No user associated
+        kid.setParent(parent);
+        
+        when(userRepository.findByUsername(parentUsername)).thenReturn(Optional.of(parentUser));
+        when(parentRepository.findByEmail("parent@example.com")).thenReturn(Optional.of(parent));
+        when(kidRepository.findById(kidId)).thenReturn(Optional.of(kid));
+
+        assertThatThrownBy(() -> authService.deleteKid(kidId, parentUsername))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Kid user account not found");
+    }
 }


### PR DESCRIPTION
…er and AuthService

- Introduced new endpoints in AuthController for parents to delete their kids' accounts and their own accounts, secured with @PreAuthorize for role validation.
- Enhanced AuthService with methods to handle the deletion of kids and parent accounts, including necessary validation checks.
- Updated integration tests to cover the new delete functionality, ensuring proper role-based access and response handling for parent requests.